### PR TITLE
Fix usage of Apache License

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 Ruben Gees
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/library/src/androidTest/java/com/rubengees/introduction/ApplicationTest.java
+++ b/library/src/androidTest/java/com/rubengees/introduction/ApplicationTest.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction;
 
 import android.app.Application;

--- a/library/src/main/java/com/rubengees/introduction/IntroductionActivity.java
+++ b/library/src/main/java/com/rubengees/introduction/IntroductionActivity.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction;
 
 import android.annotation.TargetApi;

--- a/library/src/main/java/com/rubengees/introduction/IntroductionBuilder.java
+++ b/library/src/main/java/com/rubengees/introduction/IntroductionBuilder.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction;
 
 import android.app.Activity;

--- a/library/src/main/java/com/rubengees/introduction/IntroductionConfiguration.java
+++ b/library/src/main/java/com/rubengees/introduction/IntroductionConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction;
 
 import android.support.v4.view.ViewPager;

--- a/library/src/main/java/com/rubengees/introduction/IntroductionFragment.java
+++ b/library/src/main/java/com/rubengees/introduction/IntroductionFragment.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction;
 
 

--- a/library/src/main/java/com/rubengees/introduction/adapter/PagerAdapter.java
+++ b/library/src/main/java/com/rubengees/introduction/adapter/PagerAdapter.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.adapter;
 
 import android.support.v4.app.Fragment;

--- a/library/src/main/java/com/rubengees/introduction/common/DepthPageTransformer.java
+++ b/library/src/main/java/com/rubengees/introduction/common/DepthPageTransformer.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.common;
 
 import android.support.v4.view.ViewPager;

--- a/library/src/main/java/com/rubengees/introduction/common/DotIndicatorManager.java
+++ b/library/src/main/java/com/rubengees/introduction/common/DotIndicatorManager.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.common;
 
 import android.support.annotation.NonNull;

--- a/library/src/main/java/com/rubengees/introduction/common/NumberIndicatorManager.java
+++ b/library/src/main/java/com/rubengees/introduction/common/NumberIndicatorManager.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.common;
 
 import android.support.annotation.NonNull;

--- a/library/src/main/java/com/rubengees/introduction/common/ZoomOutPageTransformer.java
+++ b/library/src/main/java/com/rubengees/introduction/common/ZoomOutPageTransformer.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.common;
 
 import android.support.v4.view.ViewPager;

--- a/library/src/main/java/com/rubengees/introduction/entity/Option.java
+++ b/library/src/main/java/com/rubengees/introduction/entity/Option.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.entity;
 
 import android.content.Context;

--- a/library/src/main/java/com/rubengees/introduction/entity/Slide.java
+++ b/library/src/main/java/com/rubengees/introduction/entity/Slide.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.entity;
 
 import android.content.Context;

--- a/library/src/main/java/com/rubengees/introduction/interfaces/IndicatorManager.java
+++ b/library/src/main/java/com/rubengees/introduction/interfaces/IndicatorManager.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.interfaces;
 
 import android.support.annotation.IntRange;

--- a/library/src/main/java/com/rubengees/introduction/interfaces/ViewPagerProcessor.java
+++ b/library/src/main/java/com/rubengees/introduction/interfaces/ViewPagerProcessor.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.interfaces;
 
 /**

--- a/library/src/main/java/com/rubengees/introduction/util/ButtonManager.java
+++ b/library/src/main/java/com/rubengees/introduction/util/ButtonManager.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.util;
 
 import android.support.annotation.NonNull;

--- a/library/src/main/java/com/rubengees/introduction/util/OrientationUtils.java
+++ b/library/src/main/java/com/rubengees/introduction/util/OrientationUtils.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.util;
 
 import android.app.Activity;

--- a/library/src/main/java/com/rubengees/introduction/util/Utils.java
+++ b/library/src/main/java/com/rubengees/introduction/util/Utils.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introduction.util;
 
 import android.content.res.Resources;

--- a/sample/src/androidTest/java/com/rubengees/introductionsample/ApplicationTest.java
+++ b/sample/src/androidTest/java/com/rubengees/introductionsample/ApplicationTest.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introductionsample;
 
 import android.app.Application;

--- a/sample/src/main/java/com/rubengees/introductionsample/MainActivity.java
+++ b/sample/src/main/java/com/rubengees/introductionsample/MainActivity.java
@@ -1,3 +1,19 @@
+/*
+ *   Copyright 2015 Ruben Gees
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package com.rubengees.introductionsample;
 
 import android.Manifest;


### PR DESCRIPTION
The LICENSE file must contain the original license text. There might be
additional information or some modifications, but the copyright comment
is for single file use by using the at the end of the license mentioned
boilerplate notice as file header in each file staying under that
license.
